### PR TITLE
replace compile() with implementation()

### DIFF
--- a/src/android/build/localnotification.gradle
+++ b/src/android/build/localnotification.gradle
@@ -28,5 +28,5 @@ if (!project.ext.has('appShortcutBadgerVersion')) {
 }
 
 dependencies {
-    compile "me.leolin:ShortcutBadger:${appShortcutBadgerVersion}@aar"
+    implementation "me.leolin:ShortcutBadger:${appShortcutBadgerVersion}@aar"
 }


### PR DESCRIPTION
This replaces the deprecated compile() with implementation() and succeeds the build on cordova-android 11.0.0 and above